### PR TITLE
Add directions for libsgx-uae-service

### DIFF
--- a/docs/node-guides/setup-sgx.md
+++ b/docs/node-guides/setup-sgx.md
@@ -106,6 +106,11 @@ fi
 sudo apt install -y $PSW_PACKAGES
 ```
 
+Install the libsgx-uae-service
+```
+sudo apt-get install libsgx-uae-service
+```
+
 # Testing your SGX setup
 
 ### Run `secretd init-enclave`


### PR DESCRIPTION
If this is not done, I got the following error:
secretd init-enclave
secretd: error while loading shared libraries: libsgx_uae_service.so: cannot open shared object file: No such file or directory