### PR TITLE
Update capitalizations + check links

### DIFF
--- a/docs/protocol/encryption-specs.md
+++ b/docs/protocol/encryption-specs.md
@@ -28,7 +28,7 @@
     - [On the transaction sender](#on-the-transaction-sender)
     - [On the consensus layer, inside the enclave of every full node](#on-the-consensus-layer-inside-the-enclave-of-every-full-node-1)
   - [Output](#output)
-    - [On the consensus layer, inside the Enclave of every full node](#on-the-consensus-layer-inside-the-enclave-of-every-full-node-2)
+    - [On the consensus layer, inside the enclave of every full node](#on-the-consensus-layer-inside-the-enclave-of-every-full-node-2)
     - [Back on the transaction sender](#back-on-the-transaction-sender)
 - [Blockchain upgrades](#blockchain-upgrades)
 - [Theoretical attacks](#theoretical-attacks)


### PR DESCRIPTION
All links are correct. Remove 'encryption' heading in table of contents b/c it is redundant. Update case of headings / subheadings to be consistent. The term 'enclave' is consistently lower case in other parts of the documentation so made document reflect that. @dylanschultzie 