### PR TITLE
chore(docs): remove outdated link

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Mainnet is out! Get the latest version [HERE.](https://github.com/scrtlabs/Secre
 
 Secret Network uses the SCRT coin (Secret) for fees, staking, governance, and to secure the network. View transactions, validators, governance proposals, and more using the following Secret Network block explorers:
 
-- [Cashmaney](https://explorer.cashmaney.com)
 - [secretnodes](https://secretnodes.com)
 
 # Wallets


### PR DESCRIPTION
The link for one of the explorers is leading to another page which has nothing to do with scrt.