### PR TITLE
Fix broken link to CLI install instructions

### DIFF
--- a/docs/dev/quickstart.md
+++ b/docs/dev/quickstart.md
@@ -277,7 +277,7 @@ Pulsar-2 is the testnet you will use to deploy your contract, follow these steps
 
 #### Install and configure the Secret Network Light Client
 
-If you don't have the latest `secretd`, using these [steps](https://github.com/scrtlabs/SecretNetwork/blob/master/docs/testnet/install_cli.md) to download the CLI and add its location to your PATH.
+If you don't have the latest `secretd`, using these [steps](https://github.com/SecretFoundation/docs/blob/main/docs/cli/install-cli.md) to download the CLI and add its location to your PATH.
 
 Before deploying your contract make sure it's configured to point to an existing RPC node. You can also use the testnet bootstrap node. Set the `chain-id` to `pulsar-2`. Below we've also got a config setting to point to the `test` keyring backend which allows you to interact with the testnet and your contract without providing an account password each time.
 


### PR DESCRIPTION
### Description of the Change
In the section about deploying to pulsar testnet, the link to the CLI installation instructions was pointing to a file that no longer exists. I updated it to point to the `install-cli.md` file in this repo.