### PR TITLE
Major Typo in addr_humanize definition

### DIFF
--- a/development/versioning-and-changelog/migration-from-cw-0.10-to-1.0.md
+++ b/development/versioning-and-changelog/migration-from-cw-0.10-to-1.0.md
@@ -5,7 +5,7 @@
 ### Address API Changes
 
 * `HumanAddr` has been deprecated in favour of simply `String`. It never added any significant safety bonus over `String` and was just a marker type. The new type `Addr` was created to hold validated addresses. Those can be created via `Addr::unchecked`, `Api::addr_validate`, `Api::addr_humanize` and JSON deserialization. In order to maintain type safety, deserialization into `Addr` must only be done from trusted sources like a contract's state or a query response. User inputs must be deserialized into `String`.
-* `deps.api.human_address(&CanonicalAddr)` => `deps.api.addr_humanize(&str)`
+* `deps.api.human_address(&CanonicalAddr)` => `deps.api.addr_humanize(&CanonicalAddr)`
 * `deps.api.canonical_address(&HumanAddr)` => `deps.api.addr_canonicalize(&str)`
 
 ### Extern Method Interface Changes


### PR DESCRIPTION
I'm pretty sure this is a typo, but anyhow addr_humanize actually takes Canonical_addr instead of a string. Check example [here](https://github.com/CosmWasm/cosmwasm/blob/c106596acdcfbee4ad6abed73491301874605215/packages/std/src/traits.rs#L103)