### PR TITLE
prevent secretd v1.8.0 runtime error Creating file 'node-master-key.txt' failed

### DIFF
--- a/infrastructure/upgrade-instructions/cosmovisor.md
+++ b/infrastructure/upgrade-instructions/cosmovisor.md
@@ -45,6 +45,7 @@ After=network.target
 
 [Service]
 Type=simple
+WorkingDirectory=${HOME}
 ExecStart=/bin/cosmovisor run start
 User=${USER}
 Restart=on-failure


### PR DESCRIPTION
secretd v1.8.0 fails with
```
 ERROR [enclave_utils::results] Creating file 'node-master-key.txt' failed
```

If WorkingDirectory is not set.