### PR TITLE
Fix Windows instructions and update secretcli versions

### DIFF
--- a/development/getting-started/compile-and-deploy.md
+++ b/development/getting-started/compile-and-deploy.md
@@ -56,7 +56,8 @@ make build
 
 {% tab title="Windows" %}
 ```
-RUSTFLAGS='-C link-arg=-s' cargo build --release --target wasm32-unknown-unknown
+$env:RUSTFLAGS='-C link-arg=-s'
+cargo build --release --target wasm32-unknown-unknown
 cp ./target/wasm32-unknown-unknown/release/*.wasm ./contract.wasm
 ```
 {% endtab %}

--- a/development/getting-started/interacting-with-the-testnet.md
+++ b/development/getting-started/interacting-with-the-testnet.md
@@ -85,7 +85,8 @@ make build
 
 {% tab title="Windows" %}
 ```
-RUSTFLAGS='-C link-arg=-s' cargo build --release --target wasm32-unknown-unknown
+$env:RUSTFLAGS='-C link-arg=-s'
+cargo build --release --target wasm32-unknown-unknown
 cp ./target/wasm32-unknown-unknown/release/*.wasm ./contract.wasm
 ```
 {% endtab %}

--- a/development/getting-started/setting-up-your-environment.md
+++ b/development/getting-started/setting-up-your-environment.md
@@ -26,7 +26,7 @@ We're going to install our environment manually so that you can code in a text e
 
 ### Install Requirements
 
-To follow along with the guide, we will be using `git,` `make,` `rust,` and `docker`.
+To follow along with the guide, we will be using `git`, `make`, `rust`, and `docker`.
 
 {% tabs %}
 {% tab title="Linux/WSL" %}
@@ -213,6 +213,8 @@ Congrats! You now have a containerized version of LocalSecret running inside doc
 <figure><img src="../../.gitbook/assets/LocalSecret.png" alt=""><figcaption><p>LocalSecret developer testnet</p></figcaption></figure>
 
 Now it's time to learn how to compile and deploy your first smart contract 🎉
+
+### Additional Resources
 
 <details>
 

--- a/development/getting-started/setting-up-your-environment.md
+++ b/development/getting-started/setting-up-your-environment.md
@@ -50,11 +50,13 @@ brew install make
 {% endtab %}
 
 {% tab title="Windows" %}
-Install `git` (for Windows):
+Install `git` and `perl` (for Windows):
 
 1. Go to [https://git-scm.com/download/win](https://git-scm.com/download/win) and the download will start automatically. Note that this is a project called Git for Windows, which is separate from Git itself; for more information on it, go to [https://gitforwindows.org](https://gitforwindows.org/).
 
-**Note:** support for \*\*\*\* `make` on Windows is pretty shit, so we'll provide separate commands for Windows where necessary
+2. Go to [https://strawberryperl.com](https://strawberryperl.com) and download the recommended version for your system. StrawberryPerl is an open-source Perl environment for Windows; for more information, visit [https://perl.org](https://www.perl.org/get.html#win32). Perl is used to build other dependencies that will be installed later.
+
+**Note:** support for `make` on Windows is limited, so we'll provide separate commands for Windows where necessary
 {% endtab %}
 {% endtabs %}
 
@@ -78,7 +80,7 @@ Download and run [`rustup-init.exe`](https://static.rust-lang.org/rustup/dist/i6
 {% endtab %}
 
 {% tab title="Windows (GUI)" %}
-Download and run [the Rust .msi installer](https://static.rust-lang.org/dist/rust-1.62.1-aarch64-pc-windows-msvc.msi)
+Download and run [the Rust .msi installer](https://static.rust-lang.org/dist/rust-1.68.2-x86_64-pc-windows-msvc.msi)
 {% endtab %}
 {% endtabs %}
 
@@ -122,11 +124,23 @@ sudo mv secretcli-Linux /usr/local/bin/secretcli
 {% endtab %}
 
 {% tab title="Windows (PowerShell)" %}
+
+Run the following commands in Powershell to download the latest version of SecretCLI and add it to your profile's PATH:
+
 ```powershell
-wget -O secretcli-Windows.exe https://github.com/scrtlabs/SecretNetwork/releases/download/v1.6.1/secretcli-Windows
+mkdir "$home\appdata\local\secretcli"
+wget -O "$home/appdata/local/secretcli/secretcli.exe" https://github.com/scrtlabs/SecretNetwork/releases/latest/download/secretcli-Windows
+$old_path = [Environment]::GetEnvironmentVariable('path', 'user');
+$new_path = $old_path + ';' + "$home\appdata\local\secretcli"
+[Environment]::SetEnvironmentVariable('path', $new_path,'User');
 ```
 
-TODO: Add \`secretcli-Windows.exe\` to the PATH
+Afterwards, restart the terminal and test the installation with the following command:
+
+```powershell
+secretcli version
+```
+
 {% endtab %}
 
 {% tab title="MacOS (Intel)" %}

--- a/development/getting-started/setting-up-your-environment.md
+++ b/development/getting-started/setting-up-your-environment.md
@@ -117,7 +117,7 @@ SecretCLI is a command-line tool that lets us interact with the Secret Network b
 {% tabs %}
 {% tab title="Linux" %}
 ```bash
-wget https://github.com/scrtlabs/SecretNetwork/releases/download/v1.6.0/secretcli-Linux
+wget https://github.com/scrtlabs/SecretNetwork/releases/latest/download/secretcli-Linux
 chmod +x secretcli-Linux
 sudo mv secretcli-Linux /usr/local/bin/secretcli
 ```
@@ -144,7 +144,7 @@ secretcli version
 {% endtab %}
 
 {% tab title="MacOS (Intel)" %}
-Download `secretcli` for your system [here](https://github.com/scrtlabs/SecretNetwork/releases/download/v1.6.1/secretcli-macOS).
+Download `secretcli` for your system [here](https://github.com/scrtlabs/SecretNetwork/releases/latest/download/secretcli-macOS).
 
 Set the file name to `secretcli` and set it as executable
 
@@ -155,7 +155,7 @@ chmod 755 secretcli
 {% endtab %}
 
 {% tab title="MacOS (M1)" %}
-Download `secretcli` for your system [here](https://github.com/scrtlabs/SecretNetwork/releases/download/v1.6.1/secretcli-MacOS-arm64).
+Download `secretcli` for your system [here](https://github.com/scrtlabs/SecretNetwork/releases/latest/download/secretcli-MacOS-arm64).
 
 Set the file name to `secretcli` and set it as executable
 
@@ -184,7 +184,7 @@ Now that you have docker installed, open the docker application and then in your
 {% tab title="x86 (Intel/AMD)" %}
 ```bash
 docker run -it -p 9091:9091 -p 26657:26657 -p 1317:1317 -p 5000:5000 \
-  --name localsecret ghcr.io/scrtlabs/localsecret:v1.6.0
+  --name localsecret ghcr.io/scrtlabs/localsecret:latest
 ```
 {% endtab %}
 

--- a/development/tools-and-libraries/secret-cli/install.md
+++ b/development/tools-and-libraries/secret-cli/install.md
@@ -141,6 +141,44 @@ mv secretcli /usr/local/bin
 
 **Congrats! The `secretcli` is now installed!**
 
-### Windows
+### Windows (WSL)
 
-The `secretcli` is compatible for use within the Windows Subsystem for Linux (WSL).
+`secretcli-Linux` is compatible for use within the Windows Subsystem for Linux (WSL). Follow the Linux Command-line instructions to install it.
+
+### Windows (Native)
+
+After downloading secretcli-Windows you can now use the `secretcli` by using the following command inside of the folder it is located in:
+
+```
+./secretcli-Windows
+```
+
+You will see some outputs related to available commands, flags, and usage.
+
+It is recommended to rename seretcli-Windows to 'secretcli.exe', and move the executable file to a location where it is automatically executable by typing `secretcli` anywhere within the command-line.
+
+To achieve this use the following commands in a Powershell terminal, in the directory containing secretcli-Windows:
+
+```powershell
+mkdir "$home\appdata\local\secretcli"
+mv secretcli-Windows "$home/appdata/local/secretcli/secretcli.exe"
+$old_path = [Environment]::GetEnvironmentVariable('path', 'user');
+$new_path = $old_path + ';' + "$home\appdata\local\secretcli"
+[Environment]::SetEnvironmentVariable('path', $new_path,'User');
+```
+
+Restart your terminal and test the installation by running:
+
+```powershell
+secretcli
+```
+
+#### Update SecretCLI (Windows)
+
+To update or install a different version of SecretCLI on Windows, download the release of secretcli-Windows and move it to the correct location:
+
+```powershell
+mv secretcli-Windows "$home/appdata/local/secretcli/secretcli.exe"
+```
+
+The other commands do not need to be run again if they have already been run on your account.


### PR DESCRIPTION
This fixes a few things:

Under Getting Started:

- Added perl to windows requirements (required to build cargo-generate)
- Fixed Windows rust GUI installer link (was previously linking to an ARM release)
- Added instructions for adding secretcli to PATH on Windows
- Fixed contract compile commands for Windows
- Updated secretcli and localsecret versions for all OS's (the `latest` tagged release will now always be installed)
- Fixed typo and added section heading for the additional setup resources

Under Tools and Libraries:

- Added instructions to install secretcli on Windows.