### PR TITLE
Add extract directory to quicksync manual method

### DIFF
--- a/infrastructure/running-a-node-validator/setting-up-a-node-validator/node-setup/snapshot.md
+++ b/infrastructure/running-a-node-validator/setting-up-a-node-validator/node-setup/snapshot.md
@@ -54,7 +54,7 @@ secretd tendermint unsafe-reset-all --home $HOME/.secretd
 ### Decompress snapshot
 
 ```bash
-tar -axf secret.tar.zst
+tar -axf secret.tar.zst -C $HOME/.secretd
 ```
 
 ### Download latest addrbook


### PR DESCRIPTION
Changes the command to manually extract the quicksync to ensure it is extracted to the .secretd directory